### PR TITLE
Remove nodejs v4 and v6 from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: node_js
 node_js:
+  - '10'
   - '8'
-  - '6'
-  - '4'


### PR DESCRIPTION
This PR removes `v4`, `v6` ([End-of-life](https://nodejs.org/en/about/releases/) is `30th` of this month), and adds `v10` to `.travis.yml`. 