### PR TITLE
Remove object rest operator to support Node.js 8

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,11 +21,10 @@ function getIndexOfNearestSpace(string, index, shouldSearchRight) {
 }
 
 module.exports = (text, columns, options) => {
-	options = {
+	options = Object.assign({
 		position: 'end',
 		preferTruncationOnSpace: false,
-		...options
-	};
+	}, options);
 
 	const {position, space, preferTruncationOnSpace} = options;
 	let ellipsis = '…';


### PR DESCRIPTION
Object rest operator was introduced in ES2018, and was not fully supported in Node.js 8 until 8.6.0:
https://node.green/#ES2018-features-object-rest-spread-properties

Hope we can keep compatibility with all the Node.js 8 version.
We can revert this commit when we drop support of Node.js 8.