### PR TITLE
Allow users to set custom ellipsis character

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -50,6 +50,26 @@ export interface Options {
 	````
 	*/
 	readonly preferTruncationOnSpace?: boolean;
+
+	/**
+	Use a different character instead of `…`
+	
+	@default '…'
+	
+	@example
+	```
+	import cliTruncate from 'cli-truncate';
+	
+	cliTruncate('unicorns', 5, {potision: 'end'});
+	//=> 'unic…'
+	
+	cliTruncate('unicorns', 5, {position: 'end', ellipsis: '.'});
+	//=> 'unic.'
+	
+	cliTruncate('unicorns', 5, {position: 'end', ellipsis: ''});
+	//=> 'unico'
+	*/
+	ellipsis?: string;
 }
 
 /**

--- a/index.js
+++ b/index.js
@@ -23,12 +23,11 @@ export default function cliTruncate(text, columns, options) {
 	options = {
 		position: 'end',
 		preferTruncationOnSpace: false,
+		ellipsis: '…',
 		...options,
 	};
 
 	const {position, space, preferTruncationOnSpace} = options;
-	let ellipsis = '…';
-	let ellipsisWidth = 1;
 
 	if (typeof text !== 'string') {
 		throw new TypeError(`Expected \`input\` to be a string, got ${typeof text}`);
@@ -43,7 +42,7 @@ export default function cliTruncate(text, columns, options) {
 	}
 
 	if (columns === 1) {
-		return ellipsis;
+		return options.ellipsis;
 	}
 
 	const length = stringWidth(text);
@@ -55,21 +54,19 @@ export default function cliTruncate(text, columns, options) {
 	if (position === 'start') {
 		if (preferTruncationOnSpace) {
 			const nearestSpace = getIndexOfNearestSpace(text, length - columns + 1, true);
-			return ellipsis + sliceAnsi(text, nearestSpace, length).trim();
+			return options.ellipsis + sliceAnsi(text, nearestSpace, length).trim();
 		}
 
 		if (space === true) {
-			ellipsis += ' ';
-			ellipsisWidth = 2;
+			options.ellipsis += ' ';
 		}
 
-		return ellipsis + sliceAnsi(text, length - columns + ellipsisWidth, length);
+		return options.ellipsis + sliceAnsi(text, length - columns + stringWidth(options.ellipsis), length);
 	}
 
 	if (position === 'middle') {
 		if (space === true) {
-			ellipsis = ` ${ellipsis} `;
-			ellipsisWidth = 3;
+			options.ellipsis = ` ${options.ellipsis} `;
 		}
 
 		const half = Math.floor(columns / 2);
@@ -77,28 +74,27 @@ export default function cliTruncate(text, columns, options) {
 		if (preferTruncationOnSpace) {
 			const spaceNearFirstBreakPoint = getIndexOfNearestSpace(text, half);
 			const spaceNearSecondBreakPoint = getIndexOfNearestSpace(text, length - (columns - half) + 1, true);
-			return sliceAnsi(text, 0, spaceNearFirstBreakPoint) + ellipsis + sliceAnsi(text, spaceNearSecondBreakPoint, length).trim();
+			return sliceAnsi(text, 0, spaceNearFirstBreakPoint) + options.ellipsis + sliceAnsi(text, spaceNearSecondBreakPoint, length).trim();
 		}
 
 		return (
 			sliceAnsi(text, 0, half)
-				+ ellipsis
-				+ sliceAnsi(text, length - (columns - half) + ellipsisWidth, length)
+				+ options.ellipsis
+				+ sliceAnsi(text, length - (columns - half) + stringWidth(options.ellipsis), length)
 		);
 	}
 
 	if (position === 'end') {
 		if (preferTruncationOnSpace) {
 			const nearestSpace = getIndexOfNearestSpace(text, columns - 1);
-			return sliceAnsi(text, 0, nearestSpace) + ellipsis;
+			return sliceAnsi(text, 0, nearestSpace) + options.ellipsis;
 		}
 
 		if (space === true) {
-			ellipsis = ` ${ellipsis}`;
-			ellipsisWidth = 2;
+			options.ellipsis = ` ${options.ellipsis}`;
 		}
 
-		return sliceAnsi(text, 0, columns - ellipsisWidth) + ellipsis;
+		return sliceAnsi(text, 0, columns - stringWidth(options.ellipsis)) + options.ellipsis;
 	}
 
 	throw new Error(`Expected \`options.position\` to be either \`start\`, \`middle\` or \`end\`, got ${position}`);

--- a/readme.md
+++ b/readme.md
@@ -43,6 +43,10 @@ cliTruncate('안녕하세요', 3);
 const paragraph = 'Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa.';
 cliTruncate(paragraph, process.stdout.columns));
 //=> 'Lorem ipsum dolor sit amet, consectetuer adipiscing…'
+
+// Replace the ellipsis character
+cliTruncate('unicorns', 5, {position: 'end', ellipsis: '.'});
+//=> 'unic.'
 ```
 
 ## API
@@ -122,6 +126,29 @@ cliTruncate('unicorns rainbow dragons', 6, {position: 'end', preferTruncationOnS
 // preferTruncationOnSpace would have no effect if space isn't found within next 3 indexes
 cliTruncate('unicorns rainbow dragons', 6, {position: 'middle', preferTruncationOnSpace: true})
 //=> 'uni…ns'
+```
+
+##### ellipsis
+
+Type: `string`\
+Default: `false`
+
+Use a different character instead of an ellipsis at the breaking point. You can also remove the ellipsis entirely.
+
+```js
+import cliTruncate from 'cli-truncate';
+
+// With default ellipsis
+cliTruncate('unicorns', 5, {position: 'end'});
+//=> 'unic…'
+
+// With ellipsis as '.'
+cliTruncate('unicorns', 5, {position: 'end', ellipsis: '.'});
+//=> 'unic.'
+
+// With ellipsis as ''
+cliTruncate('unicorns', 5, {position: 'end', ellipsis: '.'});
+//=> 'unico'
 ```
 
 ## Related


### PR DESCRIPTION
This PR adds an option `ellipsis` that allows the user to replace the default `…` with another character.

Example:
```js
import cliTruncate from 'cli-truncate';

// Without option
cliTruncate('unicorns', 5, {position: 'end'});
//=> 'unic…'

// With option set to '.'
cliTruncate('unicorns', 5, {position: 'end', ellipsis: '.'});
//=> 'unic.'

// With option set to ''
cliTruncate('unicorns', 5, {position: "end", ellipsis: ''});
//=> 'unico'
```

Includes type definitions and documentation.

---

Closes #18 