### PR TITLE
Fix truncation exceeding maxWidth for wide characters

### DIFF
--- a/index.js
+++ b/index.js
@@ -114,6 +114,17 @@ export default function cliTruncate(text, columns, options = {}) {
 		return visible.slice(0, end) + prefix + visible.slice(end);
 	}
 
+	// Workaround: sliceAnsi rounds up when the boundary falls inside a wide character (https://github.com/chalk/slice-ansi/issues/43).
+	// Re-slice with a 1-column narrower range to stay within bounds.
+	function safeSliceAnsi(text, beginColumn, endColumn) {
+		const sliced = sliceAnsi(text, beginColumn, endColumn);
+		if (stringWidth(sliced) > endColumn - beginColumn) {
+			return sliceAnsi(text, beginColumn, endColumn - 1);
+		}
+
+		return sliced;
+	}
+
 	if (position === 'start') {
 		if (preferTruncationOnSpace) {
 			const nearestSpace = getIndexOfNearestSpace(text, length - columns + 1, true);
@@ -125,7 +136,7 @@ export default function cliTruncate(text, columns, options = {}) {
 			truncationCharacter += ' ';
 		}
 
-		const right = sliceAnsi(text, length - columns + stringWidth(truncationCharacter), length);
+		const right = safeSliceAnsi(text, length - columns + stringWidth(truncationCharacter), length);
 		return prependWithInheritedStyleFromStart(truncationCharacter, right);
 	}
 
@@ -142,10 +153,14 @@ export default function cliTruncate(text, columns, options = {}) {
 			return sliceAnsi(text, 0, spaceNearFirstBreakPoint) + truncationCharacter + sliceAnsi(text, spaceNearSecondBreakPoint, length).trim();
 		}
 
+		const truncationWidth = stringWidth(truncationCharacter);
+		const left = safeSliceAnsi(text, 0, half);
+		const rightColumns = columns - stringWidth(left) - truncationWidth;
+		const right = safeSliceAnsi(text, length - rightColumns, length);
 		return (
-			sliceAnsi(text, 0, half)
+			left
 			+ truncationCharacter
-			+ sliceAnsi(text, length - (columns - half) + stringWidth(truncationCharacter), length)
+			+ right
 		);
 	}
 
@@ -160,7 +175,7 @@ export default function cliTruncate(text, columns, options = {}) {
 			truncationCharacter = ` ${truncationCharacter}`;
 		}
 
-		const left = sliceAnsi(text, 0, columns - stringWidth(truncationCharacter));
+		const left = safeSliceAnsi(text, 0, columns - stringWidth(truncationCharacter));
 		return appendWithInheritedStyleFromEnd(left, truncationCharacter);
 	}
 

--- a/test.js
+++ b/test.js
@@ -1,4 +1,5 @@
 import test from 'ava';
+import stringWidth from 'string-width';
 import cliTruncate from './index.js';
 
 test('main', t => {
@@ -126,4 +127,29 @@ test('preserves ANSI escape codes at the end - issue #24', t => {
 	const textEndingWithReset = `Hello World${reset}`;
 	t.is(cliTruncate(textEndingWithReset, 11), `Hello World${reset}`);
 	t.is(cliTruncate(textEndingWithReset, 8), 'Hello W…');
+});
+
+test('wide characters should not exceed maxWidth - issue #28', t => {
+	const cjk = 'あいうえおかきくけこ|end';
+
+	// End position: every maxWidth should produce output within bounds
+	for (let width = 1; width <= 25; width++) {
+		const result = cliTruncate(cjk, width);
+		const actual = stringWidth(result);
+		t.true(actual <= width, `end: maxWidth=${width} → displayWidth=${actual} (${result})`);
+	}
+
+	// Start position
+	for (let width = 1; width <= 25; width++) {
+		const result = cliTruncate(cjk, width, {position: 'start'});
+		const actual = stringWidth(result);
+		t.true(actual <= width, `start: maxWidth=${width} → displayWidth=${actual} (${result})`);
+	}
+
+	// Middle position
+	for (let width = 1; width <= 25; width++) {
+		const result = cliTruncate(cjk, width, {position: 'middle'});
+		const actual = stringWidth(result);
+		t.true(actual <= width, `middle: maxWidth=${width} → displayWidth=${actual} (${result})`);
+	}
 });


### PR DESCRIPTION
## Summary

- Fixes #28 — `cliTruncate` output exceeds `columns` when the truncation boundary falls inside an East Asian wide (CJK) character
- Adds `safeSliceAnsi` wrapper that re-slices with a 1-column narrower range when `sliceAnsi` rounds up
- Applied to all three positions (`end`, `start`, `middle`)
- Workaround for chalk/slice-ansi#43

## Test plan

- [x] Added test that verifies `stringWidth(result) <= maxWidth` for all widths 1–25 across all three positions with CJK input
- [x] All existing tests pass