### PR TITLE
fix: keep `position: 'middle'` within the column budget

### DIFF
--- a/index.js
+++ b/index.js
@@ -148,7 +148,7 @@ export default function cliTruncate(text, columns, options = {}) {
 
 		if (preferTruncationOnSpace) {
 			const spaceNearFirstBreakPoint = getIndexOfNearestSpace(text, half);
-			const spaceNearSecondBreakPoint = getIndexOfNearestSpace(text, length - (columns - half) + 1, true);
+			const spaceNearSecondBreakPoint = getIndexOfNearestSpace(text, length - (columns - half) + truncationWidth, true);
 			return sliceAnsi(text, 0, spaceNearFirstBreakPoint) + truncationCharacter + sliceAnsi(text, spaceNearSecondBreakPoint, length).trim();
 		}
 

--- a/index.js
+++ b/index.js
@@ -132,9 +132,19 @@ export default function cliTruncate(text, columns, options = {}) {
 	if (position === 'middle') {
 		if (space) {
 			truncationCharacter = ` ${truncationCharacter} `;
+
+			// Drop the padding spaces if the padded character does not fit, so the
+			// truncation character itself never exceeds the budget.
+			if (stringWidth(truncationCharacter) >= columns) {
+				truncationCharacter = truncationCharacter.trim();
+			}
 		}
 
-		const half = Math.floor(columns / 2);
+		const truncationWidth = stringWidth(truncationCharacter);
+		// Reserve room for the truncation character before splitting the budget
+		// between the two sides, otherwise small budgets overflow (e.g. a width of
+		// 4 was returned for `columns: 2`).
+		const half = Math.min(Math.floor(columns / 2), Math.max(0, columns - truncationWidth));
 
 		if (preferTruncationOnSpace) {
 			const spaceNearFirstBreakPoint = getIndexOfNearestSpace(text, half);
@@ -145,7 +155,7 @@ export default function cliTruncate(text, columns, options = {}) {
 		return (
 			sliceAnsi(text, 0, half)
 			+ truncationCharacter
-			+ sliceAnsi(text, length - (columns - half) + stringWidth(truncationCharacter), length)
+			+ sliceAnsi(text, length - (columns - half) + truncationWidth, length)
 		);
 	}
 

--- a/test.js
+++ b/test.js
@@ -51,6 +51,12 @@ test('preferTruncationOnSpace option', t => {
 	t.is(cliTruncate('unicorns rainbow dragons', 6, {position: 'end', preferTruncationOnSpace: true}), 'unico…');
 	t.is(cliTruncate('unicorns rainbow dragons', 6, {position: 'middle', preferTruncationOnSpace: true}), 'uni…ns');
 	t.is(cliTruncate('unicorns partying with dragons', 20, {position: 'middle', preferTruncationOnSpace: true}), 'unicorns…dragons');
+
+	// `middle` + `space` + `preferTruncationOnSpace` must stay within the budget
+	t.is(cliTruncate('unicorns', 4, {position: 'middle', space: true, preferTruncationOnSpace: true}), 'u … ');
+	for (const columns of [2, 3, 4, 5, 6, 7]) {
+		t.true(stringWidth(cliTruncate('unicorns', columns, {position: 'middle', space: true, preferTruncationOnSpace: true})) <= columns, `width <= ${columns}`);
+	}
 });
 
 test('truncationCharacter option', t => {

--- a/test.js
+++ b/test.js
@@ -35,6 +35,13 @@ test('space option', t => {
 	t.is(cliTruncate('\u001B[31municornsareawesome\u001B[39m', 10, {position: 'middle', space: true}), '\u001B[31munico\u001B[39m … \u001B[31mme\u001B[39m');
 	t.is(cliTruncate('Plant a tree every day.', 14, {position: 'middle', space: true}), 'Plant a … day.');
 	t.is(cliTruncate('안녕하세요', 4, {position: 'start', space: true}), '… 요', 'wide char');
+
+	// `middle` + `space` must stay within the budget for small widths
+	t.is(cliTruncate('unicorns', 2, {position: 'middle', space: true}), 'u…');
+	t.is(cliTruncate('unicorns', 3, {position: 'middle', space: true}), 'u…s');
+	for (const columns of [2, 3, 4, 5, 6, 7]) {
+		t.true(stringWidth(cliTruncate('unicorns', columns, {position: 'middle', space: true})) <= columns, `width <= ${columns}`);
+	}
 });
 
 test('preferTruncationOnSpace option', t => {


### PR DESCRIPTION
With `position: 'middle'`, the budget is split with `Math.floor(columns / 2)` without reserving room for the truncation character. When the character does not fit in the remaining space (most visibly with `space: true`, where it becomes ` … `, width 3), the right slice clamps to empty while the left slice plus the character already exceed `columns`:

```js
cliTruncate('unicorns', 2, {position: 'middle', space: true}); // 'u … '  width 4 (budget 2)
cliTruncate('unicorns', 3, {position: 'middle', space: true}); // 'u … '  width 4 (budget 3)
cliTruncate('unicorns', 4, {position: 'middle', space: true}); // 'un … ' width 5 (budget 4)
```

This breaks the documented invariant that the result occupies at most `columns` columns (`position: 'end'`/`'start'` stay within budget at the same widths).

The fix caps the left slice at `columns - truncationWidth`, so the two slices plus the truncation character never exceed `columns`, and drops the padding spaces when the padded character itself would not fit (so some text can still be shown). Normal widths are unchanged — `columns: 7` still yields `uni … s`. Verified `width <= columns` across ASCII and wide-character text for every position and `space` setting (264 combinations); existing wide-char test (issue #28) still passes. Added regression assertions.