### PR TITLE
Return the text unchanged when columns is NaN

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,6 +35,13 @@ export default function cliTruncate(text, columns, options = {}) {
 		throw new TypeError(`Expected \`columns\` to be a number, got ${typeof columns}`);
 	}
 
+	// A `NaN` budget (e.g. `process.stdout.columns - n` when stdout is not a TTY)
+	// means the target width is unknown — return the text untruncated rather than
+	// appending a truncation character to the full string.
+	if (Number.isNaN(columns)) {
+		return text;
+	}
+
 	if (columns < 1) {
 		return '';
 	}

--- a/test.js
+++ b/test.js
@@ -23,6 +23,11 @@ test('main', t => {
 	t.is(cliTruncate('u', 1), 'u');
 });
 
+test('NaN columns', t => {
+	t.is(cliTruncate('unicorns', Number.NaN), 'unicorns');
+	t.is(cliTruncate('\u001B[31municorns\u001B[39m', Number.NaN), '\u001B[31municorns\u001B[39m');
+});
+
 test('space option', t => {
 	t.is(cliTruncate('unicorns', 5, {position: 'end', space: true}), 'uni …');
 	t.is(cliTruncate('unicorns', 6, {position: 'start', space: true}), '… orns');


### PR DESCRIPTION
### Issue

When `columns` is `NaN`, the input is returned with a truncation character **always appended** — so the output is longer than the input and nothing is actually truncated. It happens for any input, even an empty string:

| input | current | expected |
|---|---|---|
| `''` | `'…'` | `''` |
| `'hi'` | `'hi…'` | `'hi'` |
| `'unicorns'` | `'unicorns…'` | `'unicorns'` |

### Easy repro

```js
import cliTruncate from 'cli-truncate';

cliTruncate('unicorns', NaN);
//=> 'unicorns…'   ❌ not truncated, stray "…" appended
```

### How `NaN` shows up in practice

The common idiom of reserving a margin off the terminal width:

```js
cliTruncate(text, process.stdout.columns - 2);
```

When stdout is **not a TTY** (piped to a file, redirected, or CI), `process.stdout.columns` is `undefined`, so `undefined - 2` is `NaN`:

```
$ node demo.js > out.txt   # stdout is not a TTY
$ cat out.txt
this is a long status line…   ← stray "…", not truncated
```

### Fix

A `NaN` budget means the target width is unknown, so return the text untruncated instead of appending a truncation character. Other non-finite inputs are unchanged: `Infinity` already returned the text, negatives already returned `''`.

Added a `NaN columns` test (plain + ANSI-styled input).
