### PR TITLE
Reserve room for the truncation character in `preferTruncationOnSpace`

### DIFF
--- a/index.js
+++ b/index.js
@@ -134,7 +134,7 @@ export default function cliTruncate(text, columns, options = {}) {
 
 	if (position === 'start') {
 		if (preferTruncationOnSpace) {
-			const nearestSpace = getIndexOfNearestSpace(text, length - columns + 1, true);
+			const nearestSpace = getIndexOfNearestSpace(text, length - columns + stringWidth(truncationCharacter), true);
 			const right = sliceAnsi(text, nearestSpace, length).trim();
 			return prependWithInheritedStyleFromStart(truncationCharacter, right);
 		}
@@ -179,7 +179,7 @@ export default function cliTruncate(text, columns, options = {}) {
 
 	if (position === 'end') {
 		if (preferTruncationOnSpace) {
-			const nearestSpace = getIndexOfNearestSpace(text, columns - 1);
+			const nearestSpace = getIndexOfNearestSpace(text, columns - stringWidth(truncationCharacter));
 			const left = sliceAnsi(text, 0, nearestSpace);
 			return appendWithInheritedStyleFromEnd(left, truncationCharacter);
 		}

--- a/test.js
+++ b/test.js
@@ -66,6 +66,20 @@ test('space option', t => {
 	}
 });
 
+test('preferTruncationOnSpace respects a multi-column truncation character', t => {
+	const text = 'unicorns are awesome dragons here today';
+
+	t.is(cliTruncate(text, 6, {position: 'end', preferTruncationOnSpace: true, truncationCharacter: '...'}), 'uni...');
+	t.is(cliTruncate(text, 6, {position: 'start', preferTruncationOnSpace: true, truncationCharacter: '...'}), '...day');
+
+	for (const position of ['start', 'end']) {
+		for (let columns = 4; columns <= 20; columns++) {
+			const result = cliTruncate(text, columns, {position, preferTruncationOnSpace: true, truncationCharacter: '...'});
+			t.true(stringWidth(result) <= columns, `${position}: width ${stringWidth(result)} exceeds ${columns} for "${result}"`);
+		}
+	}
+});
+
 test('preferTruncationOnSpace option', t => {
 	t.is(cliTruncate('unicorns are awesome', 15, {position: 'start', preferTruncationOnSpace: true}), '…are awesome');
 	t.is(cliTruncate('dragons are awesome', 15, {position: 'end', preferTruncationOnSpace: true}), 'dragons are…');


### PR DESCRIPTION
`preferTruncationOnSpace` picks the cut point assuming the truncation character occupies a single column. With a wider `truncationCharacter` (for example the common `'...'`, width 3) the result exceeds `columns`.

```js
import cliTruncate from 'cli-truncate';

cliTruncate('unicorns are awesome dragons here today', 6, {
	position: 'end',
	preferTruncationOnSpace: true,
	truncationCharacter: '...',
});
//=> 'unico...'  (width 8, budget 6)

cliTruncate('unicorns are awesome dragons here today', 6, {
	position: 'start',
	preferTruncationOnSpace: true,
	truncationCharacter: '...',
});
//=> '...here today'  (width 13, budget 6)
```

The `start` and `end` `preferTruncationOnSpace` branches hard-code `length - columns + 1` and `columns - 1`, reserving a single column for the truncation character. The non-`preferTruncationOnSpace` paths already reserve `stringWidth(truncationCharacter)`, and the `middle` branch already uses `truncationWidth`. This brings the two branches in line so the result stays within `columns`.

With the default `'…'` (width 1) the output is unchanged.

Adds a regression test asserting `stringWidth(result) <= columns` for `start`/`end` + `preferTruncationOnSpace` with a multi-column truncation character.
